### PR TITLE
Print HRESULT as hex

### DIFF
--- a/src/MalwareScan.AMSI/MalwareScanner.cs
+++ b/src/MalwareScan.AMSI/MalwareScanner.cs
@@ -74,7 +74,7 @@
                         if (result != 0)
                         {
                             // logger.Error("AMSI Intialisation returned an unexpected result: {result}. Aborting.", result);
-                            throw new AMSIException($"Failed to open an AMSI Session - the Initialise call returned {result}");
+                            throw new AMSIException($"Failed to open an AMSI Session - the Initialise call returned 0x{result:X}");
                         }
 
                         return ctx;
@@ -119,7 +119,7 @@
                 return new MalwareScanTestResult()
                     {
                         IsItWorking = false,
-                        ErrorMessage = $"The attempt to scan a test string returned an unexpected result: {result}. This is an HRESULT and is not clearly defined in AMSI."
+                        ErrorMessage = $"The attempt to scan a test string returned an unexpected result: 0x{result:X}. This is an HRESULT and is not clearly defined in AMSI."
                     };
             }
 
@@ -332,7 +332,7 @@
             if (result != 0)
             {
                 // logger.Error("An unexpected result (HRESULT): {result} was returned when calling AmsiScanBuffer for {filename}. Aborting.", result, filename);
-                throw new AMSIException($"Failed to scan {filename}. The call to AmsiScanBuffer returned {result}.");
+                throw new AMSIException($"Failed to scan {filename}. The call to AmsiScanBuffer returned 0x{result:X}.");
             }
 
             // logger.Debug($"{nameof(this.Scan)} is returning {{result}} for {{filename}}", scanResult, filename);
@@ -357,7 +357,7 @@
             if (result != 0)
             {
                 // logger.Error("AMSI OpenSession returned an unexpected result: {result}. Aborting.", result);
-                throw new AMSIException($"Failed to open an AMSI Session - the OpenSession call returned {result}");
+                throw new AMSIException($"Failed to open an AMSI Session - the OpenSession call returned 0x{result:X}");
             }
 
             return session;


### PR DESCRIPTION
The AMSI functions do return a HRESULT statuscode (see https://docs.microsoft.com/en-us/windows/win32/api/amsi/nf-amsi-amsiinitialize#return-value for example). HRESULT statuscodes are usually handled in HEX format so formatting the error messages accordingly makes it easier to search for errors on the internet.

This PR formats the returncodes given by the native AMSI API as hex numbers which are then wrapped in an appropriate `AMSIException` (if the returncode was not equal to zero).

**For example:**
*Before*
> Failed to open an AMSI Session - the Initialise call returned -2147024637

*After*
> Failed to open an AMSI Session - the Initialise call returned 0x80070103
