### PR TITLE
Update .NET targets and NuGet references

### DIFF
--- a/src/MalwareScan.AMSI/MalwareScan.AMSI.csproj
+++ b/src/MalwareScan.AMSI/MalwareScan.AMSI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0;net461;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Version>1.1.0</Version>
     <Authors>flytzen</Authors>
     <Company>NewOrbit Ltd</Company>

--- a/tests/MalwareScan.AMSI.Tests/MalwareScan.AMSI.Tests.csproj
+++ b/tests/MalwareScan.AMSI.Tests/MalwareScan.AMSI.Tests.csproj
@@ -1,15 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452;net461;net471</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated the main project to target just .NET Standard 2.0 as .NET Framework 4.6.1 and newer as well as .NET Core 2.0 and newer including .NET 6 support it. Furthermore, .NET Frameworks older than 4.6.2 will be end-of-life this year and therefore support for them should be dropped.

The test project was updated to .NET Framework 4.8 and .NET 6 as those are the current LTS releases and .NET Core 3.1 as well as .NET Framework 4.5.2 and 4.6.1 will be end-of-life this year.